### PR TITLE
ハンドアウト編集の遷移変更

### DIFF
--- a/homaster/templates/homaster/engawa.html
+++ b/homaster/templates/homaster/engawa.html
@@ -50,7 +50,11 @@
           <table class="ho-table row">
             <tr class="ho-table-tanzaku">
               <td class="ho-table-id">
+                {% if player.is_gm %}
+                <a href="{% url 'homaster:update' handout.id %}">{{ handout.ho_name }}</a>
+                {% else %}
                 <a href="{% url 'homaster:detail' handout.id %}">{{ handout.ho_name }}</a>
+                {% endif %}
               </td>
               <td class="ho-table-name-type">PC名:</td>
               <td class="ho-table-name">{{ handout.pc_name|default_if_none:"（未指定）" }}</td>


### PR DESCRIPTION
GMのENGAWAでハンドアウト名をクリック
→【修正前】詳細画面に遷移
→【修正後】編集画面に遷移
PLのENGAWAでハンドアウト名をクリック
→【修正前】詳細画面に遷移
→【修正後】詳細画面に遷移（変更なし）